### PR TITLE
update the recist reports and waterfall

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -161,5 +161,10 @@ config.deleteNoAimStudy =
   false;
 
 config.trustPath = process.env.TRUST_PATH || config.trustPath || undefined;
+// the default is the last response starting version 1.0.0
+config.bestResponse =
+  (process.env.BEST_RESPONSE && process.env.BEST_RESPONSE === 'true') ||
+  config.bestResponse ||
+  false;
 
 module.exports = config;

--- a/test/data/patient7_recist_nolesion3.json
+++ b/test/data/patient7_recist_nolesion3.json
@@ -51,8 +51,8 @@
         "tResponseCats": [
             "BL",
             "SD",
-            "PD",
-            "PD"
+            "SD",
+            "SD"
         ],
         "tUIDs": [
             [

--- a/test/data/waterfall_adla_project.json
+++ b/test/data/waterfall_adla_project.json
@@ -1,1 +1,1 @@
-{"series":[{"name":"7","project":"reporting","y":-22.329647931526658,"color": "#5a5289","rc": "SD"}]}
+{"series":[{"name":"7","project":"reporting","y":59.45420651880203,"color": "#cd6679","rc": "PD"}]}

--- a/test/data/waterfall_recist_project.json
+++ b/test/data/waterfall_recist_project.json
@@ -1,1 +1,1 @@
-{"series":[{"name":"7","project":"reporting","y":-0.19390825546299983,"color": "#5a5289","rc": "SD"}]}
+{"series":[{"name":"7","project":"reporting","y":8.53401213555247,"color": "#5a5289","rc": "SD"}]}

--- a/test/projectTest.js
+++ b/test/projectTest.js
@@ -88,6 +88,9 @@ beforeEach(() => {
       `${config.dicomWebConfig.qidoSubPath}/studies/1.2.752.24.7.19011385.453825/series/1.3.6.1.4.1.5962.99.1.3988.9480.1511522532838.2.3.1.1000`
     )
     .reply(200);
+  nock(config.dicomWebConfig.baseUrl)
+    .delete(`${config.dicomWebConfig.qidoSubPath}/studies/1.2.752.24.7.19011385.453825`)
+    .reply(200);
 
   nock(config.statsEpad)
     .put('/epad/statistics/')

--- a/utils/recist.js
+++ b/utils/recist.js
@@ -574,7 +574,9 @@ function makeTable(data, filteredTable, modality, numofHeaderCols, hideCols) {
     .append(
       addRow(
         data,
-        'Sum Lesion Diameters (cm)',
+        // u24 data is mm. 
+        // TODO get it from the data
+        'Sum Lesion Diameters (mm)',
         data.tSums,
         '',
         numofHeaderCols,
@@ -591,16 +593,17 @@ function makeTable(data, filteredTable, modality, numofHeaderCols, hideCols) {
         hideCols
       )
     )
-    .append(
-      addRow(
-        data,
-        'RR from Minimum',
-        data.tRRMin,
-        '%',
-        numofHeaderCols,
-        hideCols
-      )
-    )
+    // removing rrmin
+    // .append(
+    //   addRow(
+    //     data,
+    //     'RR from Minimum',
+    //     data.tRRMin,
+    //     '%',
+    //     numofHeaderCols,
+    //     hideCols
+    //   )
+    // )
     .attr('border', 1)
     .css('background-color', '#666666')
     .css('color', '#d4dadd');
@@ -1057,9 +1060,10 @@ function fillInTables(
   if (data.tSums == null) {
     data.tSums = calcSums(filteredTable, data.stTimepoints, numofHeaderCols);
     data.tRRBaseline = calcRRBaseline(sums, data.stTimepoints);
-    data.tRRMin = calcRRMin(sums, data.stTimepoints);
+    // data.tRRMin = calcRRMin(sums, data.stTimepoints);
+    // use rrbaseline for response cats
     data.tResponseCats = calcResponseCat(
-      data.tRRMin,
+      data.tRRBaseline,
       data.stTimepoints,
       isThereANewLesion(data),
       sums
@@ -1155,12 +1159,13 @@ function makeCalcs(shrinkedData, numofHeaderCols) {
     shrinkedData.tSums,
     shrinkedData.stTimepoints
   );
-  shrinkedData.tRRMin = calcRRMin(
-    shrinkedData.tSums,
-    shrinkedData.stTimepoints
-  );
+  // shrinkedData.tRRMin = calcRRMin(
+  //   shrinkedData.tSums,
+  //   shrinkedData.stTimepoints
+  // );
+  // use rrbaseline for response cats
   shrinkedData.tResponseCats = calcResponseCat(
-    shrinkedData.tRRMin,
+    shrinkedData.tRRBaseline,
     shrinkedData.stTimepoints,
     isThereANewLesion(shrinkedData),
     shrinkedData.tSums


### PR DESCRIPTION
update the recist reports to use rrbaseline instead of rrmin to calculate the response category. update the waterfall response category to use the last response instead of best response. the admin can  change the behavior by setting BEST_RESPONSE environment variable to true. update the tests